### PR TITLE
Fix wrong Github API domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Arguments:
  - **brokerhost**: mosquitto websocket host (for use with freeboard)
  - **brokeruser**: mosquitto websocket user (for use with freeboard)
  - **brokerpw**: mosquitto websocket password (for use with freeboard)
- - **registry**: container registry address (e.g. hub.docker.com)
+ - **registry**: container registry address (e.g. registry-1.docker.io for dockerhub)
  - **registry_user**: username for the registry account
  - **registry_passwd**: plaintext password for the registry account (or token if 2FA is enabled)
  - **registry_email**: email address for the registry account (required if using Docker Hub)

--- a/iot-gateway.sh
+++ b/iot-gateway.sh
@@ -39,7 +39,7 @@ if [ "$registry" = "hub.foundries.io" ]; then
         exit 1
     fi
     hub=hub.foundries.io
-elif [ "$registry" = "hub.docker.com" ]; then
+elif [ "$registry" = "registry-1.docker.io" ]; then
     hub=opensourcefoundries
 else
     hub=${HUB}


### PR DESCRIPTION
It seems like hub.docker.com is only the web interface, at least no API endpoint could be found when I tried to execute the script.

After some research, I found that registry-1.docker.io is a possible endpoint for API calls (see https://github.com/docker/distribution/issues/1841).

I changed this to the 'correct' API endpoint, then it worked like a charm. Can you reproduce the same behaviour, or does hub.docker.com work?